### PR TITLE
Pass the ParsedModule to the custom proprocessor

### DIFF
--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -22,7 +22,7 @@ import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 import qualified Data.Text as T
 
 data IdeOptions = IdeOptions
-  { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
+  { optPreprocessor :: GHC.ParsedModule -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
   , optGhcSession :: Action (FilePath -> Action HscEnvEq)
@@ -78,7 +78,7 @@ clientSupportsProgress caps = IdeReportProgress $ Just True ==
 
 defaultIdeOptions :: Action (FilePath -> Action HscEnvEq) -> IdeOptions
 defaultIdeOptions session = IdeOptions
-    {optPreprocessor = IdePreprocessedSource [] []
+    {optPreprocessor = IdePreprocessedSource [] [] . pm_parsed_source
     ,optGhcSession = session
     ,optExtensions = ["hs", "lhs"]
     ,optPkgLocationOpts = defaultIdePkgLocationOptions


### PR DESCRIPTION
Currently, we pass the `ParsedSource` to the custom proprocessor.
Unfortunately, the `ParsedSource` does not contain any information
about the language extensions used in a module. In `damlc`, we would
like to issue warnings when certain language extensions are used.

This PR changes the input of the custom proprocessor to be of type
`ParsedModule`. A `ParsedModule` contains, among other things, the
`ParsedSource` as well as a `ModSummary`, which contains information
about the language extensions in use. This allows the proprocessor
to do all the things it can currenty do and to have access to the
language extensions as well.

I did deliberately not change the return type of the preprocessor
since I don't need this feature and I don't fully understand the
impact this could have if used the wrong way.