### PR TITLE
Revert "Pass the ParsedModule to the custom proprocessor"

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -370,7 +370,7 @@ getModSummaryFromBuffer fp contents dflags parsed = do
 -- parsed module (or errors) and any parse warnings. Does not run any preprocessors
 parseFileContents
        :: GhcMonad m
-       => (GHC.ParsedModule -> IdePreprocessedSource)
+       => (GHC.ParsedSource -> IdePreprocessedSource)
        -> DynFlags -- ^ flags to use
        -> FilePath  -- ^ the filename (for source locations)
        -> SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
@@ -405,19 +405,19 @@ parseFileContents customPreprocessor dflags filename contents = do
                  throwE $ diagFromErrMsgs "parser" dflags $ snd $ getMessages pst dflags
 
                -- Ok, we got here. It's safe to continue.
-               ms <- getModSummaryFromBuffer filename contents dflags rdr_module
+               let IdePreprocessedSource preproc_warns errs parsed = customPreprocessor rdr_module
+               unless (null errs) $ throwE $ diagFromStrings "parser" DsError errs
+               let preproc_warnings = diagFromStrings "parser" DsWarning preproc_warns
+               ms <- getModSummaryFromBuffer filename contents dflags parsed
                let pm =
                      ParsedModule {
                          pm_mod_summary = ms
-                       , pm_parsed_source = rdr_module
+                       , pm_parsed_source = parsed
                        , pm_extra_src_files=[] -- src imports not allowed
                        , pm_annotations = hpm_annotations
                       }
-               let IdePreprocessedSource preproc_warns errs preprocessedSource = customPreprocessor pm
-               unless (null errs) $ throwE $ diagFromStrings "parser" DsError errs
-               let preproc_warnings = diagFromStrings "parser" DsWarning preproc_warns
-               let warnings = diagFromErrMsgs "parser" dflags warns
-               pure (warnings ++ preproc_warnings, pm {pm_parsed_source = preprocessedSource})
+                   warnings = diagFromErrMsgs "parser" dflags warns
+               pure (warnings ++ preproc_warnings, pm)
 
 loadHieFile :: FilePath -> IO GHC.HieFile
 loadHieFile f = do

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -22,7 +22,7 @@ import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 import qualified Data.Text as T
 
 data IdeOptions = IdeOptions
-  { optPreprocessor :: GHC.ParsedModule -> IdePreprocessedSource
+  { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
   , optGhcSession :: Action (FilePath -> Action HscEnvEq)
@@ -78,7 +78,7 @@ clientSupportsProgress caps = IdeReportProgress $ Just True ==
 
 defaultIdeOptions :: Action (FilePath -> Action HscEnvEq) -> IdeOptions
 defaultIdeOptions session = IdeOptions
-    {optPreprocessor = IdePreprocessedSource [] [] . pm_parsed_source
+    {optPreprocessor = IdePreprocessedSource [] []
     ,optGhcSession = session
     ,optExtensions = ["hs", "lhs"]
     ,optPkgLocationOpts = defaultIdePkgLocationOptions


### PR DESCRIPTION
Reverts digital-asset/daml-ghcide#3

The reordering in `parseFileContents` causes problems in situations where the preprocessor changes the imports of a file.

I will solve the problem #3 was intended to solve in a different way in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml-ghcide/5)
<!-- Reviewable:end -->
