### PR TITLE
Pass the DynFlags to the preprocessor

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -370,7 +370,7 @@ getModSummaryFromBuffer fp contents dflags parsed = do
 -- parsed module (or errors) and any parse warnings. Does not run any preprocessors
 parseFileContents
        :: GhcMonad m
-       => (GHC.ParsedSource -> IdePreprocessedSource)
+       => (DynFlags -> GHC.ParsedSource -> IdePreprocessedSource)
        -> DynFlags -- ^ flags to use
        -> FilePath  -- ^ the filename (for source locations)
        -> SB.StringBuffer -- ^ Haskell module source text (full Unicode is supported)
@@ -405,7 +405,7 @@ parseFileContents customPreprocessor dflags filename contents = do
                  throwE $ diagFromErrMsgs "parser" dflags $ snd $ getMessages pst dflags
 
                -- Ok, we got here. It's safe to continue.
-               let IdePreprocessedSource preproc_warns errs parsed = customPreprocessor rdr_module
+               let IdePreprocessedSource preproc_warns errs parsed = customPreprocessor dflags rdr_module
                unless (null errs) $ throwE $ diagFromStrings "parser" DsError errs
                let preproc_warnings = diagFromStrings "parser" DsWarning preproc_warns
                ms <- getModSummaryFromBuffer filename contents dflags parsed

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -22,7 +22,7 @@ import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 import qualified Data.Text as T
 
 data IdeOptions = IdeOptions
-  { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
+  { optPreprocessor :: GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
   , optGhcSession :: Action (FilePath -> Action HscEnvEq)
@@ -78,7 +78,7 @@ clientSupportsProgress caps = IdeReportProgress $ Just True ==
 
 defaultIdeOptions :: Action (FilePath -> Action HscEnvEq) -> IdeOptions
 defaultIdeOptions session = IdeOptions
-    {optPreprocessor = IdePreprocessedSource [] []
+    {optPreprocessor = \_dflags -> IdePreprocessedSource [] []
     ,optGhcSession = session
     ,optExtensions = ["hs", "lhs"]
     ,optPkgLocationOpts = defaultIdePkgLocationOptions


### PR DESCRIPTION
Currently, we pass only the `ParsedSource` to the custom proprocessor.
Unfortunately, the `ParsedSource` does not contain any information
about the language extensions used in a module. In `damlc`, we would
like to issue warnings when certain language extensions are used.

This PR improves the situation by passing the `DynFlags` to the
preprocessor as well. The `DynFlags` contain a list of all the enabled
language extensions and hence all the information we need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml-ghcide/6)
<!-- Reviewable:end -->
