### PR TITLE
Fix the pretty printer for diagnostic locations

### DIFF
--- a/src/Development/IDE/Types/Diagnostics.hs
+++ b/src/Development/IDE/Types/Diagnostics.hs
@@ -67,7 +67,7 @@ type FileDiagnostic = (NormalizedFilePath, ShowDiagnostic, Diagnostic)
 
 prettyRange :: Range -> Doc Terminal.AnsiStyle
 prettyRange Range{..} = f _start <> "-" <> f _end
-    where f Position{..} = pretty (_line+1) <> colon <> pretty _character
+    where f Position{..} = pretty (_line+1) <> colon <> pretty (_character+1)
 
 stringParagraphs :: T.Text -> Doc a
 stringParagraphs = vcat . map (fillSep . map pretty . T.words) . T.lines


### PR DESCRIPTION
The error/warning location columns printed by `daml build` have been
off by one from those in DAML Studio for ages. I would argue that
DAML Studio has the ultimate authority on this since we can't change
what it displays without moving the squiggly lines.

This has consistently annoyed me when dealing with error locations in
the `damlc` integration tests but I never had the patience of figuring
out what caused the issue. Now, that I'm on a roll adding PRs to
`ghcide`, seems to be the right time to fix this.

If we merge this here, I'll make the same request with more positive
wording against upstream `ghcide`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml-ghcide/7)
<!-- Reviewable:end -->
