### PR TITLE
Stop -Werror from failing on warnings not turned on by user

### DIFF
--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1210,6 +1210,19 @@ addSigActionTests = let
     , "a >>>> b = a + b"        >:: "(>>>>) :: Num a => a -> a -> a"
     , "a `haha` b = a b"        >:: "haha :: (t1 -> t2) -> t1 -> t2"
     , "pattern Some a = Just a" >:: "pattern Some :: a -> Maybe a"
+    , testSession "-Werror with missing signatures" $ do
+        doc <- createDoc "Sigs.hs" "haskell" $ T.unlines
+          ["{-# OPTIONS_GHC -Werror -Wmissing-signatures #-}"
+          , "module Sigs where"
+          , "f = 42"
+          ]
+        expectDiagnostics [("Sigs.hs", [(DsError, (2, 0), "Top-level binding with no type signature")])]
+        changeDoc doc [TextDocumentContentChangeEvent Nothing Nothing $ T.unlines
+          ["{-# OPTIONS_GHC -Werror #-}"
+          , "module Sigs where"
+          , "f = 42"
+          ]]
+        expectDiagnostics [("Sigs.hs", [])]
     ]
 
 addSigLensesTests :: TestTree


### PR DESCRIPTION
We turn on certain warnings temporarily to make sure we get
diagnostics and can use them in code lenses. However, the way -Werror
works this means those warnings end up being errors which is obviously
not what we intended. This PR fixes this by removing the warnings we
turn on magically from fatal warnings if the warning is not turned on
explicitly.