### PR TITLE
Add flag for building locally without Daml-capable GHC

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -148,6 +148,13 @@ library
         Development.IDE.Plugin.Completions.Logic
         Development.IDE.Plugin.Completions.Types
     ghc-options: -Wall -Wno-name-shadowing
+    if flag(no_daml)
+        cpp-options: -DNO_DAML
+
+Flag no_daml
+    Description: Build without Daml-capable GHC by enabling -DNO_DAML, so isDamlGenerated is stubbed out
+    Manual: True
+    Default: False
 
 executable ghcide-test-preprocessor
     default-language: Haskell2010

--- a/src/Development/IDE/LSP/Outline.hs
+++ b/src/Development/IDE/LSP/Outline.hs
@@ -34,7 +34,13 @@ import           Outputable                     ( Outputable
                                                 , showSDocUnsafe
                                                 )
 
+#ifdef NO_DAML
+import OccName (HasOccName)
+isDamlGenerated :: HasOccName a => a -> Bool
+isDamlGenerated = const False
+#else
 import RdrHsSyn (isDamlGenerated)
+#endif
 
 moduleOutline
   :: IdeState -> DocumentSymbolParams -> LspM c (Either ResponseError (List DocumentSymbol |? List SymbolInformation))

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -28,7 +28,6 @@ import Type
 import Var
 import Packages
 import DynFlags
-import RdrHsSyn (isDamlGenerated)
 #if MIN_GHC_API_VERSION(8,10,0)
 import Predicate (isDictTy)
 import GHC.Platform
@@ -45,6 +44,13 @@ import Development.IDE.GHC.Error
 import Development.IDE.Types.Options
 import Development.IDE.Spans.Common
 import Development.IDE.GHC.Util
+
+#ifdef NO_DAML
+isDamlGenerated :: HasOccName a => a -> Bool
+isDamlGenerated = const False
+#else
+import RdrHsSyn (isDamlGenerated)
+#endif
 
 -- From haskell-ide-engine/hie-plugin-api/Haskell/Ide/Engine/Context.hs
 


### PR DESCRIPTION
We stub out `isDamlGenerated`, which is the only daml-specific thing we currently import. This lets devs use `cabal build`, ghcid, etc. locally in this repo to build, before trying to build with the rest of the `digital-asset/daml` repo